### PR TITLE
Change mod internal name to exogenesis

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -1,6 +1,6 @@
 {
   "displayName": "[cyan]JSONgenesis Redux",
-  "name": "jsongenesis",
+  "name": "exogenesis",
   "author": "[blue]AureusStratus, revamped by Rosnok",
   "description": "The old JSON version of Exogenesis, revamped. /nA mod that adds in alot of content",
   "minGameVersion": "137",


### PR DESCRIPTION
Change mod internal name to exogenesis to allow you to use previous exogenesis progress with the mod.